### PR TITLE
List events from all selected calendars and not only "primary" calendar

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,4 +1,3 @@
-from calendar import calendar
 from adapt.intent import IntentBuilder
 from mycroft import MycroftSkill, intent_file_handler
 from mycroft.messagebus.message import Message

--- a/__init__.py
+++ b/__init__.py
@@ -156,6 +156,13 @@ class GoogleCalendarSkill(MycroftSkill):
                             name='calendar_connect')
 
     def get_next_all_calendars(self, now):
+        """
+        Searches all calendars for the next event.
+        Searches only non-whole-day events.
+
+        Returns:
+            (event[]): array containing only the next event, empty if none is found
+        """
         calendarListResults = self.service.calendarList().list().execute()
         calendarList = []
         for result in calendarListResults.get('items', []):
@@ -168,7 +175,7 @@ class GoogleCalendarSkill(MycroftSkill):
                 calendarId=calendarId, timeMin=now, maxResults=10,
                 singleEvents=True, orderBy='startTime').execute()
             events = eventsResult.get('items', [])
-            if events != []:
+            if events and not is_wholeday_event(events[0]):
                 start = events[0]['start'].get('dateTime')
                 d = datetime.strptime(remove_tz(start), '%Y-%m-%dT%H:%M:%S')
                 if nextEvent is None:


### PR DESCRIPTION
Asking for events now searches all calendars which are active in the Calendar UI for events instead of only the "primary" calendar.
The events get ordered by start time with regards to all calendars.